### PR TITLE
Versions Folder Fix

### DIFF
--- a/source/CreditsState.hx
+++ b/source/CreditsState.hx
@@ -1,3 +1,6 @@
+/*
+ * Guys it would be so funny if I made this an easter egg, but as of now, idk why this is still here lmao.
+ */
 package;
 
 import flash.text.TextField;

--- a/source/Prefs.hx
+++ b/source/Prefs.hx
@@ -1,0 +1,93 @@
+package;
+
+import flixel.FlxG;
+
+/**
+ * Alright, the basics are here for preferences stuff.
+ */
+class Prefs
+{
+	public static var versionsFolder(default, set):String;
+
+	static var isInitialized:Bool = false;
+
+	static function set_versionsFolder(folder:String):String
+	{
+		PlayState.versionsFolderPath = folder;
+		versionsFolder = folder;
+
+		if (isInitialized) // This is probs f'ing stupid to do but 🖕/j
+			save();
+
+		if (PlayState.directoryText != null)
+			PlayState.directoryText.text = 'Current Directory:\n$folder';
+
+		return versionsFolder;
+	}
+
+	/**
+	 * Keeps track of FlxG.sound.muted
+	 * 
+	 * NOT IMPLEMENTED
+	 */
+	public static var muteSound(default, set):Bool = false;
+
+	static function set_muteSound(value:Bool):Bool
+	{
+		FlxG.sound.muted = value;
+		muteSound = value;
+
+		if (isInitialized) // This is probs f'ing stupid to do but 🖕/j
+			save();
+
+		return value;
+	}
+
+	/**
+	 * This determines what goes before the version string e.g. "Universe Engine 5.5.0".
+	 * 
+	 * NOT IMPLEMENTED
+	 */
+	public static var nameBeforeVersion:String = '';
+
+	public static function load():Void
+	{
+		if (FlxG.save.data.vf != null)
+		{
+			set_versionsFolder(FlxG.save.data.vf);
+		}
+		if (FlxG.save.data.ms != null)
+		{
+			muteSound = FlxG.save.data.ms;
+		}
+		if (FlxG.save.data.nbv != null)
+		{
+			nameBeforeVersion = FlxG.save.data.nbv;
+		}
+		if (FlxG.save.data.mute != null) {}
+	}
+
+	public static function save():Void
+	{
+		FlxG.save.data.vf = versionsFolder;
+		FlxG.save.data.ms = muteSound;
+		FlxG.save.data.nbv = nameBeforeVersion;
+
+		FlxG.save.flush();
+	}
+
+	public static function initialize():Void
+	{
+		FlxG.save.bind('UE_Launcher', 'Video_Bot'); // PREFS NEED A HOME LMAO
+
+		#if sys
+		set_versionsFolder(haxe.io.Path.directory(haxe.io.Path.directory(Sys.programPath()) + "/versions/"));
+		#else
+		set_versionsFolder('./versions/');
+		#end
+		FlxG.sound.playMusic(Paths.music('this_prevents_the_game_from_crashing'), 0);
+
+		isInitialized = true;
+		load();
+	}
+}

--- a/source/Prefs.hx
+++ b/source/Prefs.hx
@@ -34,7 +34,7 @@ class Prefs
 
 	static function set_muteSound(value:Bool):Bool
 	{
-		FlxG.sound.muted = value;
+		//FlxG.sound.muted = value;
 		muteSound = value;
 
 		if (isInitialized) // This is probs f'ing stupid to do but 🖕/j
@@ -85,7 +85,7 @@ class Prefs
 		#else
 		set_versionsFolder('./versions/');
 		#end
-		FlxG.sound.playMusic(Paths.music('this_prevents_the_game_from_crashing'), 0);
+		//FlxG.sound.playMusic(Paths.music('this_prevents_the_game_from_crashing'), 0);
 
 		isInitialized = true;
 		load();

--- a/source/import.hx
+++ b/source/import.hx
@@ -1,0 +1,10 @@
+/*
+ * This is here because it's so annoying to have to re-import all of these.
+ */
+
+#if !macro
+import flixel.FlxG;
+import flixel.FlxSprite;
+import flixel.FlxState;
+import flixel.text.FlxText;
+#end


### PR DESCRIPTION
yuh.

Changes in this PR:

- The Version Folder button actually changes where versions get saved.
- Added the Prefs class for storing the Version Folder location, and contains 2 extra variables as a basis for options in the not currently made options menu
- Added import.hx to simplify creating new classes/states.
- Added a message to show when the launcher starts unzipping files, with a delay to allow the text to update before unzipping.
- Added new text to display the current Version Folder location
- Made the text displaying download status have a black border so it doesn't blend into the background accidentally.